### PR TITLE
Switch arrays for enums and create new tests

### DIFF
--- a/src/Card.ts
+++ b/src/Card.ts
@@ -1,47 +1,27 @@
-//export enum Suit {
-//  Diamonds = 'Diamonds',
-//  Spades = 'Spades',
-//  Hearts = 'Hearts',
-//  Clubs = 'Clubs',
-//}
-//
-//export enum Rank {
-//  Two = 2,
-//  Three = 3,
-//  Four = 4,
-//  Five = 5,
-//  Six = 6,
-//  Seven = 7,
-//  Eight = 8,
-//  Nine = 9,
-//  Ten = 10,
-//  Jack = 11,
-//  Queen = 12,
-//  King = 13,
-//  Ace = 14,
-//}
+export enum Suit {
+  Diamonds = 'Diamonds',
+  Spades = 'Spades',
+  Hearts = 'Hearts',
+  Clubs = 'Clubs',
+}
 
-export const suits = ['diamonds', 'spades', 'hearts', 'clubs'] as const;
+export enum Rank {
+  Two = 2,
+  Three = 3,
+  Four = 4,
+  Five = 5,
+  Six = 6,
+  Seven = 7,
+  Eight = 8,
+  Nine = 9,
+  Ten = 10,
+  Jack = 11,
+  Queen = 12,
+  King = 13,
+  Ace = 14,
+}
 
-export type Suit = typeof suits[number];
-
-export const ranks = [
-  'two',
-  'three',
-  'four',
-  'five',
-  'six',
-  'seven',
-  'eight',
-  'nine',
-  'ten',
-  'jack',
-  'queen',
-  'king',
-  'ace',
-] as const;
-
-export type Rank = typeof ranks[number];
+//export type Rank = typeof ranks[number];
 
 export default class Card {
   public suit: Suit;

--- a/src/Deck.ts
+++ b/src/Deck.ts
@@ -1,4 +1,4 @@
-import { default as Card, Rank, Suit, ranks, suits } from './Card';
+import { default as Card, Rank, Suit } from './Card';
 
 interface DeckOptions {
   seed?: number;
@@ -15,11 +15,11 @@ export default class Deck {
   constructor(options: DeckOptions = {}) {
     // TODO add jokers
     const { seed = Math.random(), shuffle = true } = options;
-    for (const suit of suits) {
-      for (const rank of ranks) {
-        this.cards.push(new Card(suit, rank));
-      }
-    }
+    Object.values(Suit).forEach(suit => {
+      Object.values(Rank).filter(value => typeof value === 'number').forEach(rank => {
+        this.cards.push(new Card(suit as Suit, rank as Rank));
+      });
+    });
 
     if (shuffle) {
       this.shuffle(seed);

--- a/tests/deck.test.ts
+++ b/tests/deck.test.ts
@@ -1,39 +1,28 @@
 import { mockDeck, mockShuffledDeck } from './deck.mocks';
 import Deck from '../src/Deck';
-import { Rank } from '../src/Card';
 
 describe('Deck', () => {
-  it('should create a deck with 52 cards', () => {
-    const deck = new Deck({shuffle: false});
-    expect(deck.Count).toBe(52);
-  });
-});
-
-// TODO make it check an actual seed
-describe('Deck Shuffle', () => {
-  it('should shuffle the deck of cards', () => {
-    const deck = new Deck({ shuffle: false });
-    const firstCardPreShuffle = deck.Cards[0];
-    deck.shuffle();
-    const firstCardPostShuffle = deck.Cards[0];
-
-    expect(firstCardPreShuffle).not.toEqual(firstCardPostShuffle);
-  });
-});
-
-fdescribe('Deck Enum Tes', () => {
-    const deck = new Deck({ shuffle: false });
-    const firstCardPreShuffle = deck.Cards[0];
-    expect(firstCardPreShuffle.rank).toBe(Rank.Two);
-
-});
-
-describe('Take Cards from Deck', () => {
-  it('should take the specified number of cards from the deck', () => {
+  it('should create a deck with no options passed', () => {
     const deck = new Deck();
-    const cardsTaken = deck.take(5);
-    
-    expect(cardsTaken.length).toBe(5);
-    expect(deck.Count).toBe(47);
+    expect(deck).toBeTruthy();
+  });
+  it('should create a deck of unshuffled cards', () => {
+    const deck = new Deck({ shuffle: false });
+    expect(deck.Cards).toEqual(mockDeck);
+  });
+
+  it('should create a shuffled deck of cards with specified seed', () => {
+    const seed = 0.5;
+    const deck = new Deck({ seed });
+    expect(deck.Cards).toEqual(mockShuffledDeck);
+  });
+
+  it('should be able to take X amount of cards from the deck', () => {
+    const seed = 0.5;
+    const deck = new Deck({ seed });
+    const countToTake = 5;
+    const hand = deck.take(countToTake);
+    expect(hand).toHaveLength(countToTake);
+    expect(deck.Count).toEqual(47);
   });
 });

--- a/tests/deck.test.ts
+++ b/tests/deck.test.ts
@@ -1,28 +1,39 @@
 import { mockDeck, mockShuffledDeck } from './deck.mocks';
 import Deck from '../src/Deck';
+import { Rank } from '../src/Card';
 
 describe('Deck', () => {
-  it('should create a deck with no options passed', () => {
-    const deck = new Deck();
-    expect(deck).toBeTruthy();
+  it('should create a deck with 52 cards', () => {
+    const deck = new Deck({shuffle: false});
+    expect(deck.Count).toBe(52);
   });
-  it('should create a deck of unshuffled cards', () => {
+});
+
+// TODO make it check an actual seed
+describe('Deck Shuffle', () => {
+  it('should shuffle the deck of cards', () => {
     const deck = new Deck({ shuffle: false });
-    expect(deck.Cards).toEqual(mockDeck);
-  });
+    const firstCardPreShuffle = deck.Cards[0];
+    deck.shuffle();
+    const firstCardPostShuffle = deck.Cards[0];
 
-  it('should create a shuffled deck of cards with specified seed', () => {
-    const seed = 0.5;
-    const deck = new Deck({ seed });
-    expect(deck.Cards).toEqual(mockShuffledDeck);
+    expect(firstCardPreShuffle).not.toEqual(firstCardPostShuffle);
   });
+});
 
-  it('should be able to take X amount of cards from the deck', () => {
-    const seed = 0.5;
-    const deck = new Deck({ seed });
-    const countToTake = 5;
-    const hand = deck.take(countToTake);
-    expect(hand).toHaveLength(countToTake);
-    expect(deck.Count).toEqual(47);
+fdescribe('Deck Enum Tes', () => {
+    const deck = new Deck({ shuffle: false });
+    const firstCardPreShuffle = deck.Cards[0];
+    expect(firstCardPreShuffle.rank).toBe(Rank.Two);
+
+});
+
+describe('Take Cards from Deck', () => {
+  it('should take the specified number of cards from the deck', () => {
+    const deck = new Deck();
+    const cardsTaken = deck.take(5);
+    
+    expect(cardsTaken.length).toBe(5);
+    expect(deck.Count).toBe(47);
   });
 });


### PR DESCRIPTION
Changes arrays that are used to generate and define card ranks and suits, for enums. Also new tests.

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github/emobe/croupier/tree/33-rank-suit-enums"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github/emobe/croupier/tree/33-rank-suit-enums)._